### PR TITLE
java.lang.IllegalStateException: Maximum number of attachments exceeded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <version.org.jboss.logmanager>2.1.17.Final</version.org.jboss.logmanager>
         <version.org.slf4j>1.7.30</version.org.slf4j>
         <!-- Test dependencies -->
-        <version.junit>4.12</version.junit>
+        <version.junit>4.13.1</version.junit>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <properties>
         <version.org.jboss.logmanager>2.1.17.Final</version.org.jboss.logmanager>
         <version.org.slf4j>1.7.30</version.org.slf4j>
+        <!-- Test dependencies -->
+        <version.junit>4.12</version.junit>
     </properties>
 
     <licenses>
@@ -71,6 +73,14 @@
             <artifactId>slf4j-api</artifactId>
             <version>${version.org.slf4j}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/slf4j/impl/LoggerTestCase.java
+++ b/src/test/java/org/slf4j/impl/LoggerTestCase.java
@@ -1,0 +1,139 @@
+package org.slf4j.impl;
+
+import org.jboss.logmanager.LogContext;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggerTestCase {
+    private static final java.util.logging.Logger ROOT = LogContext.getLogContext().getLogger("");
+    private static final QueueHandler HANDLER = new QueueHandler();
+    private static final Collection<Handler> CURRENT_HANDLERS = new ArrayList<>();
+
+    @BeforeClass
+    public static void configureLogManager() {
+        // By default JBoss Logging should choose JUL as a log manager since no log manager has been defined
+        final Handler[] currentHandlers = ROOT.getHandlers();
+        if (currentHandlers != null) {
+            for (Handler handler : currentHandlers) {
+                CURRENT_HANDLERS.add(handler);
+                ROOT.removeHandler(handler);
+            }
+        }
+        ROOT.addHandler(HANDLER);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        ROOT.removeHandler(HANDLER);
+        for (Handler handler : CURRENT_HANDLERS) {
+            ROOT.addHandler(handler);
+        }
+    }
+
+    @After
+    public void clearHandler() {
+        HANDLER.reset();
+    }
+
+    @Test
+    public void testLogger() {
+        final Logger logger = LoggerFactory.getLogger(LoggerTestCase.class);
+        assertTrue(expectedTypeMessage(Slf4jLogger.class, logger.getClass()),
+                logger instanceof Slf4jLogger);
+
+        // Ensure the logger logs something
+        final String testMsg = "This is a test message";
+        logger.info(testMsg);
+        LogRecord record = HANDLER.messages.poll();
+        assertNotNull(record);
+        assertEquals("Expected message not found.", testMsg, record.getMessage());
+        assertNull("Expected parameters to be null, when no args.", record.getParameters());
+
+        // Test a formatted message
+        logger.info("This is a test formatted {}", "message");
+        record = HANDLER.messages.poll();
+        assertNotNull(record);
+        assertEquals("Expected formatted message not found.", "This is a test formatted message", record.getMessage());
+        assertArrayEquals("Expected parameter not found.", new Object[]{"message"}, record.getParameters());
+    }
+
+    @Test
+    public void testLoggerWithExceptions() {
+        final Logger logger = LoggerFactory.getLogger(LoggerTestCase.class);
+
+        final RuntimeException e = new RuntimeException("Test exception");
+        final String testMsg = "This is a test message";
+        logger.info(testMsg, e);
+        LogRecord record = HANDLER.messages.poll();
+        assertNotNull(record);
+        assertEquals("Expected message not found.", testMsg, record.getMessage());
+        assertEquals("Cause is different from the expected cause", e, record.getThrown());
+
+        // Test format with the last parameter being the throwable which should set be set on the record
+        logger.info("This is a test formatted {}", "message", e);
+        record = HANDLER.messages.poll();
+        assertNotNull(record);
+        assertEquals("Expected formatted message not found.", "This is a test formatted message", record.getMessage());
+        assertEquals("Cause is different from the expected cause", e, record.getThrown());
+
+    }
+
+    @Test
+    public void testMDC() {
+        assertSame(expectedTypeMessage(Slf4jMDCAdapter.class, MDC.getMDCAdapter().getClass()), MDC.getMDCAdapter().getClass(), Slf4jMDCAdapter.class);
+        final String key = Long.toHexString(System.currentTimeMillis());
+        MDC.put(key, "value");
+        assertEquals("MDC value should be \"value\"", "value", MDC.get(key));
+        assertEquals("MDC value should be \"value\"", "value", org.jboss.logmanager.MDC.get(key));
+    }
+
+    private static String expectedTypeMessage(final Class<?> expected, final Class<?> found) {
+        return String.format("Expected type %s but found type %s", expected.getName(), found.getName());
+    }
+
+    private static class QueueHandler extends Handler {
+        final BlockingDeque<LogRecord> messages = new LinkedBlockingDeque<>();
+
+        @Override
+        public void publish(final LogRecord record) {
+            messages.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            messages.clear();
+        }
+
+        void reset() {
+            messages.clear();
+            setLevel(Level.ALL);
+        }
+    }
+}


### PR DESCRIPTION
When I am trying to test the usage of this library in quarkus, I am getting this stackTrace:
```
Exception in thread "Thread-30" java.lang.ExceptionInInitializerError
        at io.netty.channel.DefaultChannelId.<clinit>(DefaultChannelId.java:60)
        at io.quarkus.netty.runtime.NettyRecorder$1.run(NettyRecorder.java:28)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.IllegalStateException: Maximum number of attachments exceeded
        at org.jboss.logmanager.LoggerNode.attachIfAbsent(LoggerNode.java:428)
        at org.jboss.logmanager.Logger.attachIfAbsent(Logger.java:194)
        at org.slf4j.impl.Slf4jLoggerFactory$1.run(Slf4jLoggerFactory.java:42)
        at org.slf4j.impl.Slf4jLoggerFactory$1.run(Slf4jLoggerFactory.java:39)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at org.slf4j.impl.Slf4jLoggerFactory.getLogger(Slf4jLoggerFactory.java:39)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:363)
        at io.netty.util.internal.logging.Slf4JLoggerFactory.newInstance(Slf4JLoggerFactory.java:49)
        at io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:92)
        at io.netty.util.internal.logging.InternalLoggerFactory.getInstance(InternalLoggerFactory.java:85)
        at io.netty.util.internal.SystemPropertyUtil.<clinit>(SystemPropertyUtil.java:29)
        ... 3 more
```