### PR TITLE
fix: marker was not propagated in log.error(Marker marker, String msg, Throwable t)

### DIFF
--- a/src/main/java/org/slf4j/impl/Slf4jLogger.java
+++ b/src/main/java/org/slf4j/impl/Slf4jLogger.java
@@ -560,7 +560,7 @@ public final class Slf4jLogger implements Serializable, LocationAwareLogger {
         if (ALT_ERROR_INT < logger.getEffectiveLevel()) {
             return;
         }
-        log(null, org.jboss.logmanager.Level.ERROR, msg, t);
+        log(marker, org.jboss.logmanager.Level.ERROR, msg, t);
     }
 
     protected Object readResolve() throws ObjectStreamException {


### PR DESCRIPTION
This is a fix for cases when  Marker is lost when using log.error(Marker marker, String msg, Throwable t)